### PR TITLE
Add script for git config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,3 +26,6 @@ if [ "$answer" != "${answer#[Yy]}" ] ;then
         sh extras_install.sh
 fi
 
+
+# configure git
+sh ./setup_git_config.sh

--- a/setup_git_config.sh
+++ b/setup_git_config.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Configure global Git user information
+
+set -e
+
+git config --global user.email 6599399+dltn@users.noreply.github.com
+git config --global user.name dltn
+
+echo "Global Git user information configured."


### PR DESCRIPTION
## Summary
- provide a script to configure global git user info
- run the config script from `install.sh`
- keep README concise

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684cf643a44c8324b25d14b125dd11a9