### PR TITLE
Add responsive status bar to tmux config

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,4 +22,9 @@ bind - split-window -v -c "#{pane_current_path}" # use '<PRE>-' to split a pane 
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
 
-run '~/.tmux/plugins/tpm/tpm' # Initialize tpm; always keep as last line (see https://github.com/tmux-plugins/tpm)
+run '~/.tmux/plugins/tpm/tpm' # Initialize tpm (keep before responsive overrides so they take precedence over theme)
+
+# - Responsive status bar: shorten window names and drop date when terminal is narrow (< 80 cols)
+set -g status-right '#{?#{e|<:#{client_width},80}, %H:%M , "#{=21:pane_title}" %H:%M %d-%b-%y}'
+set -g window-status-format '#{?#{e|<:#{client_width},80},#I:#{=3:window_name} ,#I:#W#{?window_flags,#{window_flags}, }}'
+set -g window-status-current-format '#{?#{e|<:#{client_width},80},#I:#{=3:window_name} ,#I:#W#{?window_flags,#{window_flags}, }}'


### PR DESCRIPTION
Shorten window names and drop the date when the terminal is narrower than 80 columns, keeping tmux usable in small terminals.