### PR TITLE
Show active tab indicator in narrow tmux status bar

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,4 +22,4 @@ bind -T copy-mode-vi 'y' send -X copy-selection-and-cancel
 # - Responsive status bar: shorten window names and drop date when terminal is narrow (< 80 cols)
 set -g status-right '#{?#{e|<:#{client_width},80}, %H:%M , "#{=21:pane_title}" %H:%M %d-%b-%y}'
 set -g window-status-format '#{?#{e|<:#{client_width},80},#I:#{=3:window_name} ,#I:#W#{?window_flags,#{window_flags}, }}'
-set -g window-status-current-format '#{?#{e|<:#{client_width},80},#I:#{=3:window_name} ,#I:#W#{?window_flags,#{window_flags}, }}'
+set -g window-status-current-format '#{?#{e|<:#{client_width},80},#I*#{=3:window_name} ,#I:#W#{?window_flags,#{window_flags}, }}'


### PR DESCRIPTION
Use * instead of : as separator for the current window in narrow view, matching tmux's existing convention for flagging active windows.